### PR TITLE
Add upload modal for custom layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ To define env, create an `.env` file:
 
 `VITE_APP_API_GEOSERVER`: Point to `http://localhost:8080/geoserver/`
 
+`VITE_APP_API_USERNAME` and `VITE_APP_API_PASSWORD`: Credentials for the
+backend's basic authentication used when uploading files.
+
+### Uploading custom layers
+
+Use the **Upload** button in the top bar to submit GeoTIFF, DEM or OBJ files.
+After a successful upload the new layer will appear in the sidebar where it can
+be toggled on the map.
+
 ### Generating code from the OpenAPI 3.0 schemas of the backends
 
 To ensure that we test consistent with the latest backend changes, we grab the latest apis via its provided OpenAPI 3.0 spec.

--- a/src/components/view/Topbar.tsx
+++ b/src/components/view/Topbar.tsx
@@ -1,10 +1,22 @@
-import { Box } from '@chakra-ui/react'
+import { Box, Button, useDisclosure } from '@chakra-ui/react'
+import UploadModal from './UploadModal'
 
 const Topbar = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure()
+
   return (
-    <Box as="header" className="w-full bg-gray-800 text-white p-4">
-      <h1 className="text-xl">DeckGL GIS</h1>
-    </Box>
+    <>
+      <Box
+        as="header"
+        className="w-full bg-gray-800 text-white p-4 flex justify-between items-center"
+      >
+        <h1 className="text-xl">DeckGL GIS</h1>
+        <Button size="sm" colorScheme="teal" onClick={onOpen}>
+          Upload
+        </Button>
+      </Box>
+      <UploadModal isOpen={isOpen} onClose={onClose} />
+    </>
   )
 }
 

--- a/src/components/view/UploadModal.tsx
+++ b/src/components/view/UploadModal.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Select
+} from '@chakra-ui/react'
+import axios from 'axios'
+
+import { DemsApiFp, GeotiffsApiFp, ObjmeshesApiFp } from '../../api/api'
+import { Configuration } from '../../api/configuration'
+import { useDemsStore } from '../../store/demStore'
+import { useGeotiffsStore } from '../../store/geotiffsStore'
+import { useOBJMeshesStore } from '../../store/objMeshesStore'
+
+interface UploadModalProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const UploadModal: React.FC<UploadModalProps> = ({ isOpen, onClose }) => {
+  const [name, setName] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [type, setType] = useState('GeoTIFF')
+
+  const { fetchDems } = useDemsStore()
+  const { fetchGeotiffs } = useGeotiffsStore()
+  const { fetchOBJMeshes } = useOBJMeshesStore()
+
+  const createConfiguration = () =>
+    new Configuration({
+      basePath: import.meta.env.VITE_APP_API_BASE_PATH,
+      username: import.meta.env.VITE_APP_API_USERNAME,
+      password: import.meta.env.VITE_APP_API_PASSWORD
+    })
+
+  const handleUpload = async () => {
+    if (!file) return
+    const configuration = createConfiguration()
+    try {
+      if (type === 'DEM') {
+        const api = DemsApiFp(configuration)
+        const request = await api.demsUploadDem(name, file)
+        await request(axios, configuration.basePath || '')
+        fetchDems()
+      } else if (type === 'GeoTIFF') {
+        const api = GeotiffsApiFp(configuration)
+        const request = await api.geotiffsUploadGeotiff(name, file)
+        await request(axios, configuration.basePath || '')
+        fetchGeotiffs()
+      } else if (type === 'OBJMesh') {
+        const api = ObjmeshesApiFp(configuration)
+        const request = await api.objmeshesUploadMesh(name, file)
+        await request(axios, configuration.basePath || '')
+        fetchOBJMeshes()
+      }
+      setName('')
+      setFile(null)
+      onClose()
+    } catch (error) {
+      console.error('Upload failed', error)
+    }
+  }
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Upload Layer</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <FormControl mb={3}>
+            <FormLabel>Layer Type</FormLabel>
+            <Select value={type} onChange={(e) => setType(e.target.value)}>
+              <option value="GeoTIFF">GeoTIFF</option>
+              <option value="DEM">DEM</option>
+              <option value="OBJMesh">OBJ Mesh</option>
+            </Select>
+          </FormControl>
+          <FormControl mb={3}>
+            <FormLabel>Name</FormLabel>
+            <Input value={name} onChange={(e) => setName(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>File</FormLabel>
+            <Input
+              type="file"
+              onChange={(e) => setFile(e.target.files?.[0] || null)}
+            />
+          </FormControl>
+        </ModalBody>
+        <ModalFooter>
+          <Button colorScheme="blue" mr={3} onClick={handleUpload}>
+            Upload
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  )
+}
+
+export default UploadModal


### PR DESCRIPTION
## Summary
- add modal to upload GeoTIFF, DEM or OBJ files
- show Upload button in top bar
- document env vars and uploading feature

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails to resolve modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c6235f944832688e576c4c075bd38